### PR TITLE
chore: ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+web/node_modules/
+web/dist/
+shared/metrics.json
+server/__pycache__/
+bench/__pycache__/
+.DS_Store


### PR DESCRIPTION
## Summary
- add .gitignore to exclude node_modules, build output, metrics, and caches

## Testing
- `npm test` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_68a364bbb468832ca630dd08c34f896b