### PR TITLE
Add metrics push and env injection

### DIFF
--- a/shared/.gitkeep
+++ b/shared/.gitkeep
@@ -1,0 +1,1 @@
+# metrics output directory

--- a/web/server.js
+++ b/web/server.js
@@ -2,14 +2,17 @@ import express from 'express'
 import { WebSocketServer } from 'ws'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import QRCode from 'qrcode'
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const app = express()
 app.use(express.json({ limit: '1mb' }))
 
 // Serve built client
 app.use(express.static(path.join(__dirname, 'dist')))
+
+// expose MODE to browser
+app.get('/env.js', (req, res) => {
+  res.type('application/javascript').send(`window.MODE="${process.env.MODE || 'wasm'}";`)
+})
 
 // Inject MODE to window
 app.get('/', (req, res, next) => {
@@ -22,6 +25,14 @@ let metrics = { mode: process.env.MODE || 'wasm', e2e: [], fps: [], kb_up: 0, kb
 
 app.post('/api/bench/reset', (req, res) => {
   metrics = { mode: req.body?.mode || (process.env.MODE||'wasm'), e2e: [], fps: [], kb_up:0, kb_down:0, lastDump: Date.now() }
+  res.json({ ok: true })
+})
+app.post('/api/bench/push', (req, res) => {
+  const { e2e, fps, kbps_up, kbps_down } = req.body || {}
+  if (typeof e2e === 'number') metrics.e2e.push(e2e)
+  if (typeof fps === 'number') metrics.fps.push(fps)
+  if (typeof kbps_up === 'number') metrics.kb_up = kbps_up/8
+  if (typeof kbps_down === 'number') metrics.kb_down = kbps_down/8
   res.json({ ok: true })
 })
 app.get('/api/bench/dump', (req, res) => {

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -149,12 +149,11 @@ async function initViewer(app: HTMLElement) {
   const metrics = {
     e2e_samples: [] as number[],
     fps_samples: [] as number[],
-    bytes_up: 0,
-    bytes_down: 0,
     lastFrameTime: performance.now(),
     processedFrames: 0,
     start: Date.now(),
-    mode: MODE
+    mode: MODE,
+    lastPush: 0
   }
 
   function drawBoxes(dets: any[]) {
@@ -208,8 +207,9 @@ async function initViewer(app: HTMLElement) {
         const idx = Math.floor(0.95*(s.length-1))
         return s[idx]
       }
-      const kbps_up = detector.bytesUp / 1024 * 8
-      const kbps_down = detector.bytesDown / 1024 * 8
+      const elapsed = (Date.now() - metrics.start) / 1000
+      const kbps_up = (detector.bytesUp / 1024) / elapsed * 8
+      const kbps_down = (detector.bytesDown / 1024) / elapsed * 8
       mpre.textContent = JSON.stringify({
         processed_fps: median(metrics.fps_samples).toFixed(1),
         e2e_ms_median: Math.round(median(metrics.e2e_samples)),
@@ -218,6 +218,16 @@ async function initViewer(app: HTMLElement) {
         kbps_down: Math.round(kbps_down),
         samples: metrics.e2e_samples.length
       }, null, 2)
+
+      // push to server ~1Hz for bench metrics
+      if (Date.now() - metrics.lastPush > 1000) {
+        metrics.lastPush = Date.now()
+        fetch('/api/bench/push', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ e2e, fps, kbps_up, kbps_down })
+        }).catch(()=>{})
+      }
     }
     setTimeout(loop, 70) // ~14 FPS target
   }


### PR DESCRIPTION
## Summary
- expose runtime MODE via `/env.js` and add `/api/bench/push` for metric uploads
- send viewer metrics to server every second and compute bandwidth over elapsed time
- track shared metrics output directory

## Testing
- `./bench/run_bench.sh --duration 1 --mode wasm` *(fails: metrics.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a366590c7c832cb64e47fa6cb5b570