### PR TITLE
Queue WebSocket messages until connection opens

### DIFF
--- a/web/src/ws-signal.ts
+++ b/web/src/ws-signal.ts
@@ -4,6 +4,12 @@ export function startSignaling(pc: RTCPeerConnection) {
   const ws = new WebSocket(url)
 
   const handlers: Record<string, (msg:any)=>void> = {}
+  const queue: string[] = []
+
+  ws.onopen = () => {
+    // Flush any messages that were queued while the socket was connecting
+    while (queue.length > 0) ws.send(queue.shift()!)
+  }
 
   ws.onmessage = async (ev) => {
     const msg = JSON.parse(ev.data)
@@ -17,7 +23,11 @@ export function startSignaling(pc: RTCPeerConnection) {
     }
   }
 
-  function send(obj:any) { ws.send(JSON.stringify(obj)) }
+  function send(obj:any) {
+    const data = JSON.stringify(obj)
+    if (ws.readyState === WebSocket.OPEN) ws.send(data)
+    else queue.push(data)
+  }
   function on(type:string, cb:(msg:any)=>void) { handlers[type]=cb }
 
   return { send, on }


### PR DESCRIPTION
## Summary
- Prevent premature WebSocket sends by queuing messages until the connection is open
- Flush queued signaling messages once the WebSocket is ready

## Testing
- `cd web && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a36f4b1d9c832c9a12f52ab2feb9d4