### PR TITLE
Serve ONNX model from local server to avoid CORS

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,11 +1,18 @@
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, FileResponse
+from fastapi.middleware.cors import CORSMiddleware
 import numpy as np
 import onnxruntime as ort
 from PIL import Image
 import io, base64, time, json, os
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Load labels
 with open("labels_coco80.txt", "r", encoding="utf-8") as f:
@@ -31,6 +38,11 @@ def _ensure_model():
     _session = ort.InferenceSession(MODEL_PATH, providers=providers)
     _input_name = _session.get_inputs()[0].name
     print("Model loaded.", flush=True)
+
+@app.get("/model")
+def get_model():
+    _ensure_model()
+    return FileResponse(MODEL_PATH, media_type="application/octet-stream")
 
 def preprocess(img: Image.Image, size=320):
     img = img.convert("RGB").resize((size, size))

--- a/web/src/wasm/detector.ts
+++ b/web/src/wasm/detector.ts
@@ -13,9 +13,9 @@ export class Detector {
     if (this.mode === 'wasm') {
       ort.env.wasm.numThreads = 1
       ort.env.wasm.simd = true
+      const modelUrl = `${location.protocol}//${location.hostname}:8000/model`
       this.session = await ort.InferenceSession.create(
-        // Tiny yolov5n exported to onnx (remote URL)
-        'https://github.com/ultralytics/yolov5/releases/download/v6.0/yolov5n.onnx',
+        modelUrl,
         { executionProviders: ['wasm'] }
       )
     } else {


### PR DESCRIPTION
## Summary
- serve the ONNX model via FastAPI with permissive CORS headers
- load the model in the browser from the local server instead of GitHub

## Testing
- `python -m py_compile server/app.py`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a37295e5a0832c985c7fa1ff6c591a