### PR TITLE
Fix mobile QR join by exposing host IP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
         - MODE=${MODE:-wasm}
     environment:
       - MODE=${MODE:-wasm}
+      - HOST_IP=${HOST_IP}
     ports:
       - "3000:3000"
     volumes:

--- a/start.sh
+++ b/start.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 
 MODE="${MODE:-wasm}"
 NGROK="${NGROK:-0}"
+# Detect host IP so QR code can reference it for phone connections
+HOST_IP="${HOST_IP:-$(hostname -I | awk '{print $1}') }"
 
-export MODE
+export MODE HOST_IP
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "Docker not found. Please install Docker Desktop first." >&2
@@ -17,6 +19,7 @@ docker compose up --build -d
 echo "=========================================="
 echo "Demo starting in MODE=$MODE"
 echo "Open http://localhost:3000 on your laptop."
+echo "Phone join URL (for QR): http://$HOST_IP:3000"
 echo "Scan QR code shown on the page with your phone."
 echo "=========================================="
 

--- a/web/server.js
+++ b/web/server.js
@@ -9,9 +9,13 @@ app.use(express.json({ limit: '1mb' }))
 // Serve built client
 app.use(express.static(path.join(__dirname, 'dist')))
 
-// expose MODE to browser
+// expose MODE and HOST_IP to browser
 app.get('/env.js', (req, res) => {
-  res.type('application/javascript').send(`window.MODE="${process.env.MODE || 'wasm'}";`)
+  const mode = process.env.MODE || 'wasm'
+  const hostIp = process.env.HOST_IP || ''
+  res
+    .type('application/javascript')
+    .send(`window.MODE="${mode}";window.HOST_IP="${hostIp}";`)
 })
 
 // Inject MODE to window

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -27,14 +27,20 @@ export function initApp() {
     </div>
   `
 
-  // QR
-  const url = new URL(location.href)
+  // QR uses HOST_IP if provided so phones can reach the laptop
+  const hostIp = (window as any).HOST_IP
+  let base = location.origin
+  if (hostIp) {
+    const port = location.port ? `:${location.port}` : ''
+    base = `${location.protocol}//${hostIp}${port}`
+  }
+  const url = new URL(base)
   url.searchParams.set('role', 'camera')
   QRCode.toCanvas(url.toString(), { width: 220 }, (err, canvas) => {
     if (!err) document.getElementById('qr')!.appendChild(canvas)
   })
   document.getElementById('joinCamera')!.onclick = () => {
-    const u = new URL(location.href); u.searchParams.set('role','camera'); location.href = u.toString()
+    const u = new URL(base); u.searchParams.set('role','camera'); location.href = u.toString()
   }
 
   const role = new URLSearchParams(location.search).get('role') || 'viewer'


### PR DESCRIPTION
## Summary
- detect laptop's network IP in `start.sh` and pass it to the web container
- expose `HOST_IP` via `/env.js` and use it when generating the camera join QR code

## Testing
- `npm --prefix web run build`
- `python -m py_compile server/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a421ee5094832cbbfc29e06a56c8f6