### PR TITLE
Add aiortc inference server

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -1,2 +1,4 @@
-Place quantized ONNX models here.
-Default: download YOLOv5n to models/yolov5n.onnx or set MODEL_PATH.
+Place ONNX detection models here.
+By default the server looks for `models/yolov5n.onnx` but any
+MobileNet-SSD or YOLOv5n model can be supplied by setting the `MODEL_PATH`
+environment variable.

--- a/server/inference.py
+++ b/server/inference.py
@@ -1,0 +1,70 @@
+import os
+import numpy as np
+import onnxruntime as ort
+from PIL import Image
+
+
+class Detector:
+    """Simple object detector using an ONNX model."""
+
+    def __init__(self, model_path: str | None = None) -> None:
+        """Load model for inference.
+
+        Args:
+            model_path: Path to ONNX model. Defaults to models/yolov5n.onnx.
+        """
+        self.model_path = model_path or os.getenv("MODEL_PATH", "models/yolov5n.onnx")
+        providers = ["CPUExecutionProvider"]
+        self.session = ort.InferenceSession(self.model_path, providers=providers)
+        self.input_name = self.session.get_inputs()[0].name
+        self.size = (320, 240)  # width, height
+
+    def _preprocess(self, frame) -> np.ndarray:
+        img = frame.to_image().resize(self.size)
+        arr = np.array(img).astype(np.float32) / 255.0
+        arr = arr.transpose(2, 0, 1)[None, ...]  # NCHW
+        return arr
+
+    def _postprocess(self, outputs, conf_thres: float = 0.25):
+        pred = outputs[0]
+        if isinstance(pred, list):
+            pred = pred[0]
+        pred = np.squeeze(pred, axis=0)
+        if pred.ndim != 2 or pred.shape[1] < 85:
+            return []
+
+        boxes = pred[:, :4]
+        objectness = pred[:, 4]
+        class_scores = pred[:, 5:]
+        scores = objectness * class_scores.max(axis=1)
+        classes = class_scores.argmax(axis=1)
+
+        keep = scores >= conf_thres
+        boxes = boxes[keep]
+        scores = scores[keep]
+        classes = classes[keep]
+
+        cx, cy, w, h = boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3]
+        xmin = np.clip(cx - w / 2, 0, 1)
+        ymin = np.clip(cy - h / 2, 0, 1)
+        xmax = np.clip(cx + w / 2, 0, 1)
+        ymax = np.clip(cy + h / 2, 0, 1)
+
+        detections = []
+        for i in range(len(scores)):
+            detections.append(
+                {
+                    "label": int(classes[i]),
+                    "score": float(scores[i]),
+                    "xmin": float(xmin[i]),
+                    "ymin": float(ymin[i]),
+                    "xmax": float(xmax[i]),
+                    "ymax": float(ymax[i]),
+                }
+            )
+        return detections
+
+    def run(self, frame):
+        inp = self._preprocess(frame)
+        outputs = self.session.run(None, {self.input_name: inp})
+        return self._postprocess(outputs)

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,77 @@
+import asyncio
+import json
+import os
+import time
+from aiohttp import web
+from aiortc import RTCPeerConnection, RTCSessionDescription
+
+from inference import Detector
+
+pcs = set()
+detector = Detector()
+
+
+async def index(request):
+    return web.Response(text="aiortc inference server", content_type="text/html")
+
+
+async def health(request):
+    return web.json_response({"ok": True})
+
+
+async def offer(request):
+    params = await request.json()
+    offer = RTCSessionDescription(sdp=params["sdp"], type=params["type"])
+
+    pc = RTCPeerConnection()
+    pcs.add(pc)
+
+    detections_channel = pc.createDataChannel("detections")
+
+    @pc.on("track")
+    async def on_track(track):
+        if track.kind == "video":
+            while True:
+                frame = await track.recv()
+                frame_id = int(frame.pts or 0)
+                recv_ts = int(time.time() * 1000)
+                detections = detector.run(frame)
+                inference_ts = int(time.time() * 1000)
+                message = {
+                    "frame_id": frame_id,
+                    "recv_ts": recv_ts,
+                    "inference_ts": inference_ts,
+                    "detections": detections,
+                }
+                if detections_channel.readyState == "open":
+                    detections_channel.send(json.dumps(message))
+
+    @pc.on("connectionstatechange")
+    async def on_state_change():
+        if pc.connectionState in ("failed", "closed"):
+            await pc.close()
+            pcs.discard(pc)
+
+    await pc.setRemoteDescription(offer)
+    answer = await pc.createAnswer()
+    await pc.setLocalDescription(answer)
+
+    return web.json_response(
+        {"sdp": pc.localDescription.sdp, "type": pc.localDescription.type}
+    )
+
+
+async def on_shutdown(app):
+    await asyncio.gather(*[pc.close() for pc in pcs])
+    pcs.clear()
+
+
+app = web.Application()
+app.router.add_get("/", index)
+app.router.add_get("/health", health)
+app.router.add_post("/offer", offer)
+app.on_shutdown.append(on_shutdown)
+
+
+if __name__ == "__main__":
+    web.run_app(app, port=int(os.getenv("PORT", 8080)))

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,5 @@
-fastapi==0.111.0
-uvicorn[standard]==0.30.1
+aiortc==1.6.0
+aiohttp==3.9.5
 onnxruntime==1.18.0
 numpy==1.26.4
 Pillow==10.3.0


### PR DESCRIPTION
## Summary
- implement aiortc server that accepts WebRTC offers, runs ONNX inference, and streams detections via data channel
- add reusable Detector class for ONNX models
- document model placement and add server requirements

## Testing
- `python -m py_compile server/main.py server/inference.py`


------
https://chatgpt.com/codex/tasks/task_e_68a441ac7fb8832cb037e98242cbfa1c