### PR TITLE
Add benchmark metric reporting and improve timestamp handling

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ export default function App() {
   const workerRef = useRef<Worker>();
   const pcRef = useRef<RTCPeerConnection | null>(null);
   const workerBusy = useRef(false);
+  const frameCountRef = useRef(0);
 
   // setup media stream
   useEffect(() => {
@@ -47,7 +48,9 @@ export default function App() {
         }
         pcRef.current = await initWebRTC(stream, msg => {
           setDetections(msg.detections);
-          metricsRef.current.record(msg.ts, performance.now());
+          const sent = msg.capture_ts ?? msg.recv_ts ?? performance.now();
+          metricsRef.current.record(sent, performance.now());
+          frameCountRef.current++;
         });
       }
     })();
@@ -64,9 +67,10 @@ export default function App() {
     workerRef.current = worker;
     worker.onmessage = ev => {
       workerBusy.current = false;
-      const { ts, detections } = ev.data;
+      const { capture_ts, detections } = ev.data;
       setDetections(detections);
-      metricsRef.current.record(ts, performance.now());
+      metricsRef.current.record(capture_ts, performance.now());
+      frameCountRef.current++;
     };
     worker.postMessage({ type: 'init' });
     return () => worker.terminate();
@@ -96,6 +100,48 @@ export default function App() {
       active = false;
     };
   }, [lowRes]);
+
+  // Periodically push FPS and bandwidth stats to bench endpoint
+  useEffect(() => {
+    let lastFrames = 0;
+    const lastBytes = { up: 0, down: 0 };
+    const id = setInterval(() => {
+      const fps = frameCountRef.current - lastFrames;
+      lastFrames = frameCountRef.current;
+      if (pcRef.current) {
+        pcRef.current.getStats().then(stats => {
+          let sent = 0;
+          let recv = 0;
+          stats.forEach(r => {
+            if (r.type === 'outbound-rtp' && (r as any).bytesSent) sent += (r as any).bytesSent;
+            if (r.type === 'inbound-rtp' && (r as any).bytesReceived) recv += (r as any).bytesReceived;
+          });
+          const kbps_up = (sent - lastBytes.up) * 8 / 1000;
+          const kbps_down = (recv - lastBytes.down) * 8 / 1000;
+          lastBytes.up = sent;
+          lastBytes.down = recv;
+          fetch('/api/bench/push', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ fps, kbps_up, kbps_down })
+          }).catch(() => {});
+        }).catch(() => {
+          fetch('/api/bench/push', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ fps })
+          }).catch(() => {});
+        });
+      } else {
+        fetch('/api/bench/push', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fps })
+        }).catch(() => {});
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
 
   const captureFrame = async (): Promise<ImageBitmap | null> => {
     const video = videoRef.current;

--- a/web/src/lib/metrics.ts
+++ b/web/src/lib/metrics.ts
@@ -8,7 +8,20 @@ export class Metrics {
   private latencies: number[] = [];
 
   record(sent: number, received: number) {
-    this.latencies.push(received - sent);
+    const latency = received - sent;
+    this.latencies.push(latency);
+    // Best-effort push to backend bench aggregator. Ignore failures so normal
+    // operation is unaffected if the endpoint is missing (e.g. outside bench
+    // runs).
+    try {
+      void fetch('/api/bench/push', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ e2e: latency })
+      });
+    } catch {
+      // no-op
+    }
   }
 
   summary(): MetricSummary {

--- a/web/src/lib/webrtc.ts
+++ b/web/src/lib/webrtc.ts
@@ -1,7 +1,10 @@
 import { Detection } from './overlay';
 
 export interface DetectionMessage {
-  ts: number;
+  frame_id?: number;
+  capture_ts?: number;
+  recv_ts?: number;
+  inference_ts?: number;
   detections: Detection[];
 }
 


### PR DESCRIPTION
## Summary
- push per-frame latency metrics to `/api/bench/push`
- expose full timestamp fields in WebRTC detection messages
- collect FPS/bandwidth stats and send to bench API

## Testing
- `npm --prefix web run build`
- `./bench/run_bench.sh --duration 1 --mode wasm` *(fails: metrics.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4484fab68832cbe6bafb8c008b394