### PR TITLE
Gracefully handle missing model and metrics push errors

### DIFF
--- a/web/src/lib/metrics.ts
+++ b/web/src/lib/metrics.ts
@@ -12,15 +12,16 @@ export class Metrics {
     this.latencies.push(latency);
     // Best-effort push to backend bench aggregator. Ignore failures so normal
     // operation is unaffected if the endpoint is missing (e.g. outside bench
-    // runs).
-    try {
+    // runs). Only attempt this when building for production to avoid noisy
+    // errors during local development.
+    if (import.meta.env.PROD) {
       void fetch('/api/bench/push', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ e2e: latency })
+      }).catch(() => {
+        /* no-op */
       });
-    } catch {
-      // no-op
     }
   }
 

--- a/web/src/lib/wasm_infer.ts
+++ b/web/src/lib/wasm_infer.ts
@@ -38,9 +38,22 @@ if (IS_WORKER) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore - the env object is only checked at runtime.
       ort.env.wasm.numThreads = 1;
-      session = await ort.InferenceSession.create(MODEL_URL, {
-        executionProviders: ['wasm']
-      });
+      try {
+        const response = await fetch(MODEL_URL);
+        if (!response.ok) {
+          throw new Error(`Model fetch failed with ${response.status} ${response.statusText}`);
+        }
+        const buffer = await response.arrayBuffer();
+        if (!buffer.byteLength) {
+          throw new Error(`Model at ${MODEL_URL} is empty`);
+        }
+        session = await ort.InferenceSession.create(buffer, {
+          executionProviders: ['wasm']
+        });
+      } catch (err) {
+        console.error('Failed to initialize ONNX model', err);
+        throw err;
+      }
     }
     return session;
   }


### PR DESCRIPTION
## Summary
- Guard metrics uploader so dev builds no longer spam 405 errors and ignore network failures
- Prefetch ONNX model with validation and clearer error reporting when missing or empty

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4bbdb1c60832c99973c96740e787a