### PR TITLE
fix: resolve model path relative to worker

### DIFF
--- a/web/src/lib/wasm_infer.ts
+++ b/web/src/lib/wasm_infer.ts
@@ -6,8 +6,13 @@ import type { Detection } from './overlay';
 // Shared constants and helpers
 // ---------------------------------------------------------------------------
 
-/** Location of the tiny quantised model used for inference. */
-const MODEL_URL = '/models/yolov5n.onnx';
+/**
+ * Location of the tiny quantised model used for inference.
+ *
+ * Use a URL relative to this script so the model can be fetched correctly
+ * whether the application is hosted at the domain root or under a sub-path.
+ */
+const MODEL_URL = new URL(/* @vite-ignore */ '../models/yolov5n.onnx', import.meta.url).toString();
 
 /** Dimensions expected by the model. */
 const SIZE = { width: 320, height: 240 } as const;


### PR DESCRIPTION
## Summary
- fetch ONNX model using a URL relative to the worker script to avoid empty responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4c9a6a308832cbfe92cc0919dcc31