### PR TITLE
fix web docker image routing for bench metrics

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -9,7 +9,10 @@ RUN npm run build
 
 FROM --platform=$TARGETPLATFORM node:18-alpine
 WORKDIR /app
-RUN npm install -g http-server
+COPY web/package*.json ./
+RUN npm ci --omit=dev
 COPY --from=build /app/dist ./dist
+COPY web/server.js ./server.js
+COPY web/public ./public
 EXPOSE 3000
-CMD ["http-server", "dist", "-p", "3000", "-a", "0.0.0.0"]
+CMD ["node", "server.js"]

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+// Avoid referencing `document` when this bundle is evaluated in
+// non-browser environments such as Web Workers.
+if (typeof document !== 'undefined') {
+  ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}


### PR DESCRIPTION
## Summary
- start Express server in web Docker image so `/api/bench/*` endpoints work
- avoid `document` reference when bundle runs outside the browser

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a56362e720832ca501f9a97b45385d