### PR TITLE
Fix bench API overshadowed by static server

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -19,9 +19,6 @@ app.use((req, res, next) => {
   next();
 });
 
-// Serve built client
-app.use(express.static(path.join(__dirname, 'dist')))
-app.use(express.static(path.join(__dirname, 'public')))
 // expose MODE to browser
 app.get('/env.js', (req, res) => {
   const mode = process.env.MODE || 'wasm'
@@ -65,6 +62,10 @@ app.get('/api/bench/dump', async (req, res) => {
   }
   res.json({ ok: true, out })
 })
+
+// Serve built client after API routes so they aren't shadowed
+app.use(express.static(path.join(__dirname, 'dist')))
+app.use(express.static(path.join(__dirname, 'public')))
 
 // ----- SINGLE HTTP SERVER + WS on same port -----
 const httpServer = http.createServer(app)


### PR DESCRIPTION
## Summary
- Move `/env.js` and bench API endpoints before static middleware
- Serve static assets after API routes to avoid 405 on `/api/bench/push`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a56f61efb8832cb70c4e41a2740e7b