### PR TITLE
feat: add bench automation and metrics endpoints

### DIFF
--- a/bench/run_bench.sh
+++ b/bench/run_bench.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 DUR=30
 MODE_ARG="wasm"
@@ -14,12 +14,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 echo "Starting bench for ${DUR}s in mode=${MODE_ARG}"
-curl -s -X POST http://localhost:3000/api/bench/reset -d '{"mode":"'"${MODE_ARG}"'"}' -H 'Content-Type: application/json' >/dev/null || true
+curl -s -X POST http://localhost:3000/bench-start \
+  -H 'Content-Type: application/json' \
+  -d '{"mode":"'"${MODE_ARG}"'"}' >/dev/null || true
 sleep "${DUR}"
-curl -s http://localhost:3000/api/bench/dump >/dev/null || true
+curl -s http://localhost:3000/bench-stop -o "${ROOT}/metrics.json" || true
 
-if [ -f "$DIR/metrics.json" ]; then
-  echo "metrics.json written to $DIR/metrics.json"
+if [ -f "${ROOT}/metrics.json" ]; then
+  echo "metrics.json written to ${ROOT}/metrics.json"
 else
   echo "metrics.json not found; ensure the app was open and running."
 fi

--- a/metrics.schema.json
+++ b/metrics.schema.json
@@ -1,14 +1,23 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["mode", "median_e2e_ms", "p95_e2e_ms", "processed_fps_median", "uplink_kbps", "downlink_kbps", "ts"],
+  "required": ["e2e_latency_ms", "processed_fps", "uplink_kbps", "downlink_kbps"],
   "properties": {
-    "mode": {"type": "string", "enum": ["wasm", "server"]},
-    "median_e2e_ms": {"type": "number"},
-    "p95_e2e_ms": {"type": "number"},
-    "processed_fps_median": {"type": "number"},
+    "e2e_latency_ms": {
+      "type": "object",
+      "required": ["median", "p95"],
+      "properties": {
+        "median": {"type": "number"},
+        "p95": {"type": "number"},
+        "histogram": {
+          "type": "array",
+          "items": {"type": "number"}
+        }
+      }
+    },
+    "processed_fps": {"type": "number"},
     "uplink_kbps": {"type": "number"},
     "downlink_kbps": {"type": "number"},
-    "ts": {"type": "integer"}
+    "mode": {"type": "string", "enum": ["wasm", "server"]}
   }
 }

--- a/web/server.js
+++ b/web/server.js
@@ -26,41 +26,79 @@ app.get('/env.js', (req, res) => {
 })
 
 // Simple metrics aggregator
-let metrics = { mode: process.env.MODE || 'wasm', e2e: [], fps: [], kb_up: 0, kb_down: 0, lastDump: 0 }
+let metrics = {
+  mode: process.env.MODE || 'wasm',
+  e2e: [],
+  fps: [],
+  kb_up: { sum: 0, count: 0 },
+  kb_down: { sum: 0, count: 0 },
+}
 
-app.post('/api/bench/reset', (req, res) => {
-  metrics = { mode: req.body?.mode || (process.env.MODE || 'wasm'), e2e: [], fps: [], kb_up: 0, kb_down: 0, lastDump: Date.now() }
+const benchStart = (req, res) => {
+  metrics = {
+    mode: req.body?.mode || process.env.MODE || 'wasm',
+    e2e: [],
+    fps: [],
+    kb_up: { sum: 0, count: 0 },
+    kb_down: { sum: 0, count: 0 },
+  }
   res.json({ ok: true })
-})
+}
+
+const benchStop = (req, res) => {
+  const median = arr => {
+    if (!arr.length) return 0;
+    const s = [...arr].sort((a, b) => a - b);
+    const m = Math.floor(s.length / 2);
+    return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+  }
+  const p95 = arr => {
+    if (!arr.length) return 0;
+    const s = [...arr].sort((a, b) => a - b);
+    const i = Math.floor(0.95 * (s.length - 1));
+    return s[i];
+  }
+  const buildHist = arr => {
+    const bins = Array(20).fill(0);
+    for (const v of arr) {
+      const idx = Math.min(bins.length - 1, Math.floor(v / 50));
+      bins[idx]++;
+    }
+    return bins;
+  }
+  const avg = m => (m.count ? m.sum / m.count : 0);
+  const out = {
+    e2e_latency_ms: {
+      median: Math.round(median(metrics.e2e)),
+      p95: Math.round(p95(metrics.e2e)),
+      histogram: buildHist(metrics.e2e),
+    },
+    processed_fps: Number(median(metrics.fps).toFixed(1)),
+    uplink_kbps: Math.round(avg(metrics.kb_up)),
+    downlink_kbps: Math.round(avg(metrics.kb_down)),
+  }
+  res.json(out)
+}
+
+app.post('/bench-start', benchStart)
+app.get('/bench-stop', benchStop)
+// Compatibility with older scripts
+app.post('/api/bench/reset', benchStart)
+app.get('/api/bench/dump', benchStop)
+
 app.post('/api/bench/push', (req, res) => {
   const { e2e, fps, kbps_up, kbps_down } = req.body || {}
   if (typeof e2e === 'number') metrics.e2e.push(e2e)
   if (typeof fps === 'number') metrics.fps.push(fps)
-  if (typeof kbps_up === 'number') metrics.kb_up = kbps_up / 8
-  if (typeof kbps_down === 'number') metrics.kb_down = kbps_down / 8
+  if (typeof kbps_up === 'number') {
+    metrics.kb_up.sum += kbps_up
+    metrics.kb_up.count++
+  }
+  if (typeof kbps_down === 'number') {
+    metrics.kb_down.sum += kbps_down
+    metrics.kb_down.count++
+  }
   res.json({ ok: true })
-})
-app.get('/api/bench/dump', async (req, res) => {
-  const median = arr => { if (!arr.length) return 0; const s = [...arr].sort((a,b)=>a-b); const m = Math.floor(s.length/2); return s.length%2 ? s[m] : (s[m-1]+s[m])/2 }
-  const p95 = arr => { if (!arr.length) return 0; const s = [...arr].sort((a,b)=>a-b); const i = Math.floor(0.95*(s.length-1)); return s[i] }
-  const out = {
-    mode: metrics.mode,
-    median_e2e_ms: Math.round(median(metrics.e2e)),
-    p95_e2e_ms: Math.round(p95(metrics.e2e)),
-    processed_fps_median: Number(median(metrics.fps).toFixed(1)),
-    uplink_kbps: Math.round(metrics.kb_up * 8),
-    downlink_kbps: Math.round(metrics.kb_down * 8),
-    ts: Date.now()
-  }
-  const fs = await import('fs')
-  try {
-    // fall back to local path if /app/bench/ isn’t mounted
-    const target = fs.existsSync('/app/bench') ? '/app/bench/metrics.json' : path.join(__dirname, 'metrics.json')
-    fs.writeFileSync(target, JSON.stringify(out, null, 2))
-  } catch (e) {
-    console.error('Failed to write metrics:', e)
-  }
-  res.json({ ok: true, out })
 })
 
 // Serve built client after API routes so they aren't shadowed


### PR DESCRIPTION
## Summary
- add bench script invoking /bench-start and /bench-stop to collect metrics
- expose /bench-start and /bench-stop endpoints on dev server with histogram-based metrics
- update metrics schema to reflect new output structure

## Testing
- `bash -n bench/run_bench.sh`
- `node --check web/server.js`
- `npm --prefix web run build`

------
https://chatgpt.com/codex/tasks/task_e_68a57f4c39c8832cb8c253365f53a7f8