### PR TITLE
Optimize overlay rendering and inference backpressure

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,7 +17,6 @@ export default function App() {
   const videoRef = useRef<HTMLVideoElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const pcRef = useRef<RTCPeerConnection | null>(null);
-  const workerBusy = useRef(false);
   const frameCountRef = useRef(0);
 
   // setup media stream
@@ -30,7 +29,7 @@ export default function App() {
         video: {
           width: lowRes ? 320 : 640,
           height: lowRes ? 240 : 480,
-          frameRate: lowRes ? 10 : 30
+          frameRate: 30
         },
         audio: false
       };
@@ -86,23 +85,23 @@ export default function App() {
   useEffect(() => {
     if (MODE !== 'wasm') return;
     let active = true;
-    const fps = lowRes ? 10 : 30;
+    const fps = 12; // clamp inference FPS
     const interval = 1000 / fps;
     let last = 0;
     const loop = async (now: number) => {
       if (!active) return;
-      if (now - last > interval && !workerBusy.current) {
+      if (now - last > interval) {
         last = now;
         const bitmap = await captureFrame();
         if (bitmap) {
-          workerBusy.current = true;
-          infer(bitmap).then(({ capture_ts, inference_ts, detections }) => {
-            workerBusy.current = false;
-            setDetections(detections);
-            metricsRef.current.record(capture_ts, inference_ts);
-            frameCountRef.current++;
+          infer(bitmap).then(output => {
+            if (output) {
+              const { capture_ts, inference_ts, detections } = output;
+              setDetections(detections);
+              metricsRef.current.record(capture_ts, inference_ts);
+              frameCountRef.current++;
+            }
           }).catch(err => {
-            workerBusy.current = false;
             console.error(err);
           });
         }

--- a/web/src/components/VideoCanvas.tsx
+++ b/web/src/components/VideoCanvas.tsx
@@ -9,6 +9,9 @@ interface Props {
 const VideoCanvas = forwardRef<HTMLVideoElement, Props>(({ stream, detections }, ref) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const offscreenRef = useRef<OffscreenCanvas | null>(null);
+  const dirtyRef = useRef(false);
+  const rafRef = useRef<number>();
 
   useImperativeHandle(ref, () => videoRef.current as HTMLVideoElement);
 
@@ -24,10 +27,37 @@ const VideoCanvas = forwardRef<HTMLVideoElement, Props>(({ stream, detections },
     if (!canvas || !video) return;
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
-    const ctx = canvas.getContext('2d');
+
+    if (!offscreenRef.current ||
+        offscreenRef.current.width !== canvas.width ||
+        offscreenRef.current.height !== canvas.height) {
+      offscreenRef.current = new OffscreenCanvas(canvas.width, canvas.height);
+    }
+
+    const ctx = offscreenRef.current.getContext('2d');
     if (!ctx) return;
     drawDetections(ctx, detections, canvas.width, canvas.height);
+    dirtyRef.current = true;
   }, [detections]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const render = () => {
+      if (dirtyRef.current && offscreenRef.current) {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(offscreenRef.current, 0, 0);
+        dirtyRef.current = false;
+      }
+      rafRef.current = requestAnimationFrame(render);
+    };
+    rafRef.current = requestAnimationFrame(render);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
 
   return (
     <div style={{ position: 'relative' }}>

--- a/web/src/lib/wasm_infer.ts
+++ b/web/src/lib/wasm_infer.ts
@@ -145,6 +145,7 @@ if (IS_WORKER) {
     const detections = postprocess(tensor.data as Float32Array);
     const inference_ts = performance.now();
     ctx.postMessage({
+      type: 'result',
       frame_id: msg.frame_id,
       capture_ts: msg.capture_ts,
       inference_ts,
@@ -176,7 +177,10 @@ if (IS_WORKER) {
     } else {
       const msg = data;
       if (busy) {
-        if (queued) closeBitmap(queued.bitmap);
+        if (queued) {
+          ctx.postMessage({ type: 'dropped', frame_id: queued.frame_id });
+          closeBitmap(queued.bitmap);
+        }
         queued = msg; // replace queued frame
       } else {
         process(msg);
@@ -198,7 +202,7 @@ export interface InferenceOutput {
 
 let worker: Worker | null = null;
 let nextFrameId = 0;
-const pending = new Map<number, (msg: InferenceOutput) => void>();
+const pending = new Map<number, (msg: InferenceOutput | null) => void>();
 let warmupResolver: (() => void) | null = null;
 
 function getWorker(): Worker {
@@ -215,6 +219,12 @@ function getWorker(): Worker {
       if (data.type === 'warmup-done') {
         warmupResolver?.();
         warmupResolver = null;
+      } else if (data.type === 'dropped') {
+        const resolver = pending.get(data.frame_id);
+        if (resolver) {
+          pending.delete(data.frame_id);
+          resolver(null);
+        }
       } else {
         const resolver = pending.get(data.frame_id);
         if (resolver) {
@@ -235,7 +245,7 @@ function warmupImpl(): Promise<void> {
   });
 }
 
-function inferImpl(bitmap: ImageBitmap | OffscreenCanvas): Promise<InferenceOutput> {
+function inferImpl(bitmap: ImageBitmap | OffscreenCanvas): Promise<InferenceOutput | null> {
   const w = getWorker();
   const frame_id = nextFrameId++;
   const capture_ts = performance.now();


### PR DESCRIPTION
## Summary
- Render detection overlays via OffscreenCanvas and requestAnimationFrame for smoother, lower-CPU updates
- Limit inference to 12 FPS while keeping video preview at 30 FPS
- Enforce bounded queue in wasm inference worker, dropping stale frames to align results with correct frame IDs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5b077d498832c953df93044931dad