### PR TITLE
Improve metrics and QR join URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Run:
 ./bench/run_bench.sh --duration 30 --mode wasm
 # or
 ./bench/run_bench.sh --duration 30 --mode server
-cat bench/metrics.json
+cat bench/metrics.json  # includes median/p95 for e2e, server and network latency
 ```
 
 ---

--- a/metrics.schema.json
+++ b/metrics.schema.json
@@ -1,7 +1,14 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["e2e_latency_ms", "processed_fps", "uplink_kbps", "downlink_kbps"],
+  "required": [
+    "e2e_latency_ms",
+    "server_latency_ms",
+    "network_latency_ms",
+    "processed_fps",
+    "uplink_kbps",
+    "downlink_kbps"
+  ],
   "properties": {
     "e2e_latency_ms": {
       "type": "object",
@@ -13,6 +20,22 @@
           "type": "array",
           "items": {"type": "number"}
         }
+      }
+    },
+    "server_latency_ms": {
+      "type": "object",
+      "required": ["median", "p95"],
+      "properties": {
+        "median": { "type": "number" },
+        "p95": { "type": "number" }
+      }
+    },
+    "network_latency_ms": {
+      "type": "object",
+      "required": ["median", "p95"],
+      "properties": {
+        "median": { "type": "number" },
+        "p95": { "type": "number" }
       }
     },
     "processed_fps": {"type": "number"},

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 # Portable script to start the demo environment.
+# QR codes use the browser's origin; when --ngrok is passed the generated
+# HTTPS URL is written to web/public/join.txt for the client to prefer.
 
 set -e
 
@@ -60,7 +62,7 @@ if [ "$NGROK" -eq 1 ]; then
       done
       if [ -n "$URL" ]; then
         printf '%s\n' "$URL" > "$JOIN_FILE"
-        echo "ngrok URL: $URL"
+        printf 'ngrok URL: %s\n' "$URL"
       else
         echo "Failed to retrieve ngrok URL; check /tmp/ngrok.log" >&2
       fi

--- a/web/server.js
+++ b/web/server.js
@@ -29,6 +29,8 @@ app.get('/env.js', (req, res) => {
 let metrics = {
   mode: process.env.MODE || 'wasm',
   e2e: [],
+  srv: [],
+  net: [],
   fps: [],
   kb_up: { sum: 0, count: 0 },
   kb_down: { sum: 0, count: 0 },
@@ -38,6 +40,8 @@ const benchStart = (req, res) => {
   metrics = {
     mode: req.body?.mode || process.env.MODE || 'wasm',
     e2e: [],
+    srv: [],
+    net: [],
     fps: [],
     kb_up: { sum: 0, count: 0 },
     kb_down: { sum: 0, count: 0 },
@@ -73,6 +77,14 @@ const benchStop = (req, res) => {
       p95: Math.round(p95(metrics.e2e)),
       histogram: buildHist(metrics.e2e),
     },
+    server_latency_ms: {
+      median: Math.round(median(metrics.srv)),
+      p95: Math.round(p95(metrics.srv)),
+    },
+    network_latency_ms: {
+      median: Math.round(median(metrics.net)),
+      p95: Math.round(p95(metrics.net)),
+    },
     processed_fps: Number(median(metrics.fps).toFixed(1)),
     uplink_kbps: Math.round(avg(metrics.kb_up)),
     downlink_kbps: Math.round(avg(metrics.kb_down)),
@@ -87,8 +99,10 @@ app.post('/api/bench/reset', benchStart)
 app.get('/api/bench/dump', benchStop)
 
 app.post('/api/bench/push', (req, res) => {
-  const { e2e, fps, kbps_up, kbps_down } = req.body || {}
+  const { e2e, fps, kbps_up, kbps_down, server_latency_ms, network_latency_ms } = req.body || {}
   if (typeof e2e === 'number') metrics.e2e.push(e2e)
+  if (typeof server_latency_ms === 'number') metrics.srv.push(server_latency_ms)
+  if (typeof network_latency_ms === 'number') metrics.net.push(network_latency_ms)
   if (typeof fps === 'number') metrics.fps.push(fps)
   if (typeof kbps_up === 'number') {
     metrics.kb_up.sum += kbps_up

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ export default function App() {
   const [lowRes, setLowRes] = useState(true);
   const [detections, setDetections] = useState<Detection[]>([]);
   const [serverDown, setServerDown] = useState(false);
+  const [joinUrl, setJoinUrl] = useState(() => window.location.origin);
   const metricsRef = useRef(new Metrics());
   const videoRef = useRef<HTMLVideoElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -60,7 +61,19 @@ export default function App() {
           pcRef.current = await initWebRTC(stream, msg => {
             setDetections(msg.detections);
             const sent = msg.capture_ts ?? msg.recv_ts ?? performance.now();
-            metricsRef.current.record(sent, performance.now());
+            const now = performance.now();
+            const serverLatency =
+              typeof msg.inference_ts === 'number' && typeof msg.recv_ts === 'number'
+                ? msg.inference_ts - msg.recv_ts
+                : undefined;
+            const networkLatency =
+              typeof msg.recv_ts === 'number' && typeof msg.capture_ts === 'number'
+                ? msg.recv_ts - msg.capture_ts
+                : undefined;
+            metricsRef.current.record(sent, now, {
+              server: serverLatency,
+              network: networkLatency,
+            });
             frameCountRef.current++;
           });
         }
@@ -189,7 +202,16 @@ export default function App() {
     URL.revokeObjectURL(url);
   };
 
-  const url = window.location.href;
+  // Prefer a join URL from the server if provided (e.g. ngrok)
+  useEffect(() => {
+    fetch('/join.txt')
+      .then(res => (res.ok ? res.text() : ''))
+      .then(text => {
+        const t = text.trim();
+        if (t) setJoinUrl(t);
+      })
+      .catch(() => {});
+  }, []);
 
   console.log('navigator.mediaDevices:', navigator && navigator.mediaDevices);
 
@@ -213,7 +235,7 @@ export default function App() {
         <button onClick={saveMetrics}>Save metrics</button>
       </div>
       <StatsPanel metrics={metricsRef.current.summary()} />
-      <QRJoin url={url} />
+      <QRJoin url={joinUrl} />
     </div>
   );
 }

--- a/web/src/lib/metrics.ts
+++ b/web/src/lib/metrics.ts
@@ -5,20 +5,27 @@ export interface MetricSummary {
 }
 
 export class Metrics {
-  private latencies: number[] = [];
+  private e2e: number[] = [];
+  private server: number[] = [];
+  private network: number[] = [];
 
-  record(sent: number, received: number) {
+  record(sent: number, received: number, extra?: { server?: number; network?: number }) {
     const latency = received - sent;
-    this.latencies.push(latency);
+    this.e2e.push(latency);
+    if (typeof extra?.server === 'number') this.server.push(extra.server);
+    if (typeof extra?.network === 'number') this.network.push(extra.network);
     // Best-effort push to backend bench aggregator. Ignore failures so normal
     // operation is unaffected if the endpoint is missing (e.g. outside bench
     // runs). Only attempt this when building for production to avoid noisy
     // errors during local development.
     if (import.meta.env.PROD) {
+      const payload: Record<string, number> = { e2e: latency };
+      if (typeof extra?.server === 'number') payload.server_latency_ms = extra.server;
+      if (typeof extra?.network === 'number') payload.network_latency_ms = extra.network;
       void fetch('/api/bench/push', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ e2e: latency })
+        body: JSON.stringify(payload)
       }).catch(() => {
         /* no-op */
       });
@@ -26,7 +33,7 @@ export class Metrics {
   }
 
   summary(): MetricSummary {
-    const arr = [...this.latencies].sort((a, b) => a - b);
+    const arr = [...this.e2e].sort((a, b) => a - b);
     const q = (p: number) =>
       arr.length ? arr[Math.min(arr.length - 1, Math.floor(p * (arr.length - 1)))] : 0;
     return {
@@ -37,6 +44,16 @@ export class Metrics {
   }
 
   toJSON() {
-    return this.summary();
+    const summarize = (arr: number[]): MetricSummary => {
+      const s = [...arr].sort((a, b) => a - b);
+      const q = (p: number) =>
+        s.length ? s[Math.min(s.length - 1, Math.floor(p * (s.length - 1)))] : 0;
+      return { count: s.length, p50: q(0.5), p95: q(0.95) };
+    };
+    return {
+      e2e_latency_ms: summarize(this.e2e),
+      server_latency_ms: summarize(this.server),
+      network_latency_ms: summarize(this.network),
+    };
   }
 }


### PR DESCRIPTION
## Summary
- Include server/network latency tracking and export in metrics
- Let web client prefer join URL from `join.txt` (e.g., ngrok)
- Document metrics and ensure start script writes ngrok URL

## Testing
- `npm test --prefix web` *(fails: Missing script "test")*
- `npm run build --prefix web`


------
https://chatgpt.com/codex/tasks/task_e_68a5b6ce7470832c9aab5c77d309d706