### PR TITLE
Fix video frame capture errors and add join placeholder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ bench/__pycache__/
 models/*.onnx
 ngrok.log
 .DS_Store
-web/public/join.txt

--- a/web/public/join.txt
+++ b/web/public/join.txt
@@ -1,0 +1,2 @@
+# Default join URL placeholder. This file prevents 404 errors when the server
+# has not written a join URL yet.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,7 +29,10 @@ export default function App() {
       const constraints: MediaStreamConstraints = {
         video: {
           width: lowRes ? 320 : 640,
-          height: lowRes ? 240 : 480,
+          // Height of 240 caused zero-dimension frames which in turn led to
+          // canvas drawImage errors and ONNXRuntime shape mismatches. Use 256
+          // which is divisible by 32 and matches the worker's expectations.
+          height: lowRes ? 256 : 480,
           frameRate: 30
         },
         audio: false
@@ -105,18 +108,24 @@ export default function App() {
       if (!active) return;
       if (now - last > interval) {
         last = now;
-        const bitmap = await captureFrame();
-        if (bitmap) {
-          infer(bitmap).then(output => {
-            if (output) {
-              const { capture_ts, inference_ts, detections } = output;
-              setDetections(detections);
-              metricsRef.current.record(capture_ts, inference_ts);
-              frameCountRef.current++;
-            }
-          }).catch(err => {
-            console.error(err);
-          });
+        // Wait for the video element to have valid dimensions before attempting
+        // to capture a frame. This prevents repeated "Video not ready" warnings
+        // and zero-sized OffscreenCanvas errors.
+        const vid = videoRef.current;
+        if (vid && vid.readyState >= 2) {
+          const bitmap = await captureFrame();
+          if (bitmap) {
+            infer(bitmap).then(output => {
+              if (output) {
+                const { capture_ts, inference_ts, detections } = output;
+                setDetections(detections);
+                metricsRef.current.record(capture_ts, inference_ts);
+                frameCountRef.current++;
+              }
+            }).catch(err => {
+              console.error(err);
+            });
+          }
         }
       }
       requestAnimationFrame(loop);
@@ -182,7 +191,7 @@ export default function App() {
     }
     const canvas = document.createElement('canvas');
     const w = lowRes ? 320 : video.videoWidth;
-    const h = lowRes ? 240 : video.videoHeight;
+    const h = lowRes ? 256 : video.videoHeight;
     canvas.width = w;
     canvas.height = h;
     const ctx = canvas.getContext('2d');

--- a/web/src/lib/wasm_infer.ts
+++ b/web/src/lib/wasm_infer.ts
@@ -15,7 +15,11 @@ import type { Detection } from './overlay';
 const MODEL_URL = new URL(/* @vite-ignore */ '../models/yolov5n.onnx', import.meta.url).toString();
 
 /** Dimensions expected by the model. */
-const SIZE = { width: 320, height: 240 } as const;
+// Model expects dimensions that are multiples of 32 to avoid shape mismatches
+// in the network. A height of 240 was causing ONNXRuntime to throw errors due
+// to incompatible concat shapes (15 vs 16). Use 256 which satisfies the
+// requirement while keeping the width at 320.
+const SIZE = { width: 320, height: 256 } as const;
 
 // ---------------------------------------------------------------------------
 // Worker implementation
@@ -71,7 +75,12 @@ if (IS_WORKER) {
   function preprocess(src: ImageBitmap | OffscreenCanvas): Tensor {
     const canvas = new OffscreenCanvas(SIZE.width, SIZE.height);
     const c = canvas.getContext('2d')!;
-    c.drawImage(src as any, 0, 0, SIZE.width, SIZE.height);
+    // Some browsers may hand us a bitmap with zero width/height if a frame is
+    // captured before the video element is ready. Avoid calling drawImage on
+    // such bitmaps as it would throw an InvalidStateError.
+    if (src.width > 0 && src.height > 0) {
+      c.drawImage(src as any, 0, 0, SIZE.width, SIZE.height);
+    }
     const rgba = c.getImageData(0, 0, SIZE.width, SIZE.height).data;
 
     const pixelCount = SIZE.width * SIZE.height;


### PR DESCRIPTION
## Summary
- prevent zero-sized canvas draws and handle early video frames
- match ONNX model expectations with 320x256 input
- add placeholder join.txt to avoid 404s

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5bcde3090832c9bec97ad9975e780