### PR TITLE
fix: guard drawImage against zero-size canvas

### DIFF
--- a/web/src/components/VideoCanvas.tsx
+++ b/web/src/components/VideoCanvas.tsx
@@ -24,7 +24,14 @@ const VideoCanvas = forwardRef<HTMLVideoElement, Props>(({ stream, detections },
   useEffect(() => {
     const canvas = canvasRef.current;
     const video = videoRef.current;
-    if (!canvas || !video) return;
+    if (
+      !canvas ||
+      !video ||
+      video.videoWidth === 0 ||
+      video.videoHeight === 0
+    ) {
+      return;
+    }
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
 


### PR DESCRIPTION
## Summary
- avoid InvalidStateError by skipping draw when video has zero dimensions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5bfde7d98832c93eb58a7c7001f6d