### PR TITLE
Ensure join file exists to avoid 404

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -39,7 +39,8 @@ while [ "$#" -gt 0 ]; do
 done
 
 JOIN_FILE="$SCRIPT_DIR/web/public/join.txt"
-rm -f "$JOIN_FILE"
+# Ensure the join file exists to avoid 404s when ngrok isn't used
+: > "$JOIN_FILE"
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "Docker not found. Please install Docker Desktop first." >&2

--- a/web/public/join.txt
+++ b/web/public/join.txt
@@ -1,2 +1,0 @@
-# Default join URL placeholder. This file prevents 404 errors when the server
-# has not written a join URL yet.


### PR DESCRIPTION
## Summary
- Keep an empty `join.txt` in the public folder and have `start.sh` truncate it instead of removing it so the client no longer hits a 404 when joining without ngrok.

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a5c1ec040c832caa625fc8269fd4c6