### PR TITLE
Drop stale frames before detection

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -34,8 +34,22 @@ async def offer(request: Request):
     @pc.on("track")
     async def on_track(track):
         if track.kind == "video":
+            queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+
+            async def reader():
+                while True:
+                    frame = await track.recv()
+                    if queue.full():
+                        try:
+                            queue.get_nowait()
+                        except asyncio.QueueEmpty:
+                            pass
+                    await queue.put(frame)
+
+            asyncio.create_task(reader())
+
             while True:
-                frame = await track.recv()
+                frame = await queue.get()
                 frame_id = int(frame.pts or 0)
                 recv_ts = int(time.time() * 1000)
                 detections = detector.run(frame)

--- a/server/main.py
+++ b/server/main.py
@@ -31,8 +31,22 @@ async def offer(request):
     @pc.on("track")
     async def on_track(track):
         if track.kind == "video":
+            queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+
+            async def reader():
+                while True:
+                    frame = await track.recv()
+                    if queue.full():
+                        try:
+                            queue.get_nowait()
+                        except asyncio.QueueEmpty:
+                            pass
+                    await queue.put(frame)
+
+            asyncio.create_task(reader())
+
             while True:
-                frame = await track.recv()
+                frame = await queue.get()
                 frame_id = int(frame.pts or 0)
                 recv_ts = int(time.time() * 1000)
                 detections = detector.run(frame)


### PR DESCRIPTION
## Summary
- Process only the most recent frame from WebRTC tracks
- Avoid backlog by queuing a single frame at a time

## Testing
- `python -m py_compile server/app.py server/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5c7e64d30832c91d94135cba1a07d