### PR TITLE
Ensure video stream plays to avoid black canvas

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -53,6 +53,11 @@ export default function App() {
         streamRef.current = stream;
         if (videoRef.current) {
           videoRef.current.srcObject = stream;
+          try {
+            await videoRef.current.play();
+          } catch (err) {
+            console.warn('Failed to play video stream', err);
+          }
         }
         if (MODE === 'server') {
           try {

--- a/web/src/components/VideoCanvas.tsx
+++ b/web/src/components/VideoCanvas.tsx
@@ -19,6 +19,7 @@ const VideoCanvas = forwardRef<HTMLVideoElement, Props>(({ stream, detections },
   useEffect(() => {
     if (videoRef.current && stream) {
       videoRef.current.srcObject = stream;
+      videoRef.current.play().catch(() => {});
     }
   }, [stream]);
 


### PR DESCRIPTION
## Summary
- Ensure camera stream plays immediately after assignment to fix blank video
- Trigger playback within VideoCanvas when stream changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5e82933c0832c9ce75d74e71fb278