### PR TITLE
Document detection IDs and expose id field

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ Then open **http://localhost:3000** on your laptop. A QR code appears — scan i
     "recv_ts": 1690000000100,
     "inference_ts": 1690000000120,
     "detections": [
-      { "label": "person", "score": 0.93, "xmin": 0.12, "ymin": 0.08, "xmax": 0.34, "ymax": 0.67 }
+      {
+        "id": 1,
+        "label": "person",
+        "score": 0.93,
+        "xmin": 0.12,
+        "ymin": 0.08,
+        "xmax": 0.34,
+        "ymax": 0.67
+      }
     ]
   }
   ```

--- a/web/src/lib/overlay.ts
+++ b/web/src/lib/overlay.ts
@@ -3,6 +3,7 @@ export interface Detection {
   y: number; // normalized top-left y
   w: number; // normalized width
   h: number; // normalized height
+  id?: number;
   label?: string;
   score?: number;
 }


### PR DESCRIPTION
## Summary
- document object tracking IDs in per-frame JSON example
- expose optional `id` in Detection TypeScript interface

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5ec9f7bc0832ca7edecaf0cfa55d8