### PR TITLE
fix: unify backend URL for frontend

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,7 +4,7 @@ import QRJoin from './components/QRJoin';
 import StatsPanel from './components/StatsPanel';
 import { Metrics } from './lib/metrics';
 import { Detection } from './lib/overlay';
-import { initWebRTC } from './lib/webrtc';
+import { initWebRTC, SERVER_URL } from './lib/webrtc';
 import { warmup, infer } from './lib/wasm_infer';
 
 const MODE = import.meta.env.VITE_MODE as 'wasm' | 'server';
@@ -61,7 +61,7 @@ export default function App() {
         }
         if (MODE === 'server') {
           try {
-            const res = await fetch('/health');
+            const res = await fetch(`${SERVER_URL}/health`);
             if (!res.ok) throw new Error('bad');
           } catch {
             setServerDown(true);

--- a/web/src/lib/webrtc.ts
+++ b/web/src/lib/webrtc.ts
@@ -8,6 +8,11 @@ export interface DetectionMessage {
   detections: Detection[];
 }
 
+// Base URL for the inference server. Using the same value everywhere ensures
+// that the frontend consistently talks to the correct backend port regardless
+// of the current origin (e.g. dev server on 3000).
+export const SERVER_URL = `${window.location.protocol}//${window.location.hostname}:8000`;
+
 export async function initWebRTC(
   stream: MediaStream,
   onMessage: (msg: DetectionMessage) => void
@@ -25,8 +30,7 @@ export async function initWebRTC(
 
   const offer = await pc.createOffer();
   await pc.setLocalDescription(offer);
-  const serverUrl = `${window.location.protocol}//${window.location.hostname}:8000`;
-  const res = await fetch(`${serverUrl}/offer`, {
+  const res = await fetch(`${SERVER_URL}/offer`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/sdp' },
     body: offer.sdp || ''


### PR DESCRIPTION
## Summary
- share SERVER_URL constant between frontend modules
- point frontend health check to backend port

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `python -m py_compile server/app.py server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5eec23fd4832c87f75d0c1348f7a0