### PR TITLE
Add index route for inference server

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -18,9 +18,17 @@ app.add_middleware(
 pcs = set()
 detector = Detector()
 
+
+@app.get("/")
+async def index():
+    """Basic index route to confirm the server is running."""
+    return {"message": "aiortc inference server"}
+
+
 @app.get("/health")
 async def health():
     return {"ok": True}
+
 
 @app.post("/offer")
 async def offer(request: Request):
@@ -77,6 +85,7 @@ async def offer(request: Request):
     await pc.setLocalDescription(answer)
 
     return Response(pc.localDescription.sdp, media_type="application/sdp")
+
 
 @app.on_event("shutdown")
 async def on_shutdown():


### PR DESCRIPTION
## Summary
- add `/` index route to FastAPI app for a friendly response instead of 404

## Testing
- `pytest`
- `python -m black server/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5f2097d28832c983923d917841f76