### PR TITLE
feat: store per-device metrics

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
+import os
 import time
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI, Query, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from aiortc import RTCPeerConnection, RTCSessionDescription
 from inference import Detector
@@ -20,8 +21,15 @@ detector = Detector()
 
 
 @app.get("/")
-async def index():
-    """Basic index route to confirm the server is running."""
+async def index(device_id: str | None = None):
+    """Return server status or metrics for a specific device."""
+    if device_id:
+        path = f"{device_id}_metrics.json"
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                data = [json.loads(line) for line in f if line.strip()]
+            return {"device_id": device_id, "metrics": data}
+        return {"device_id": device_id, "metrics": []}
     return {"message": "aiortc inference server"}
 
 
@@ -31,7 +39,7 @@ async def health():
 
 
 @app.post("/offer")
-async def offer(request: Request):
+async def offer(request: Request, device_id: str = Query(...)):
     sdp = (await request.body()).decode()
     offer = RTCSessionDescription(sdp=sdp, type="offer")
 
@@ -39,6 +47,8 @@ async def offer(request: Request):
     pcs.add(pc)
 
     detections_channel = pc.createDataChannel("detections")
+    metrics_path = f"{device_id}_metrics.json"
+    metrics_file = open(metrics_path, "a", encoding="utf-8")
 
     @pc.on("track")
     async def on_track(track):
@@ -61,16 +71,20 @@ async def offer(request: Request):
             while True:
                 frame = await queue.get()
                 frame_id = int(frame.pts or 0)
+                capture_ts = int((getattr(frame, "time", 0) or 0) * 1000)
                 recv_ts = int(time.time() * 1000)
                 detections = detector.run(frame)
                 detections = tracker.update(detections)
                 inference_ts = int(time.time() * 1000)
                 message = {
                     "frame_id": frame_id,
+                    "capture_ts": capture_ts,
                     "recv_ts": recv_ts,
                     "inference_ts": inference_ts,
                     "detections": detections,
                 }
+                metrics_file.write(json.dumps(message) + "\n")
+                metrics_file.flush()
                 if detections_channel.readyState == "open":
                     detections_channel.send(json.dumps(message))
 
@@ -79,6 +93,7 @@ async def offer(request: Request):
         if pc.connectionState in ("failed", "closed"):
             await pc.close()
             pcs.discard(pc)
+            metrics_file.close()
 
     await pc.setRemoteDescription(offer)
     answer = await pc.createAnswer()


### PR DESCRIPTION
## Summary
- log metrics for each connected device
- expose device metrics via query parameter on root route

## Testing
- `python -m py_compile server/app.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a610897a18832c8f57be3ef0f31858