### PR TITLE
feat: clarify root endpoint metrics instructions

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -30,7 +30,10 @@ async def index(device_id: str | None = None):
                 data = [json.loads(line) for line in f if line.strip()]
             return {"device_id": device_id, "metrics": data}
         return {"device_id": device_id, "metrics": []}
-    return {"message": "aiortc inference server"}
+    return {
+        "message": "aiortc inference server",
+        "hint": "add ?device_id=<id> query parameter to fetch metrics",
+    }
 
 
 @app.get("/health")

--- a/server/main.py
+++ b/server/main.py
@@ -12,7 +12,12 @@ detector = Detector()
 
 
 async def index(request):
-    return web.Response(text="aiortc inference server", content_type="text/html")
+    return web.json_response(
+        {
+            "message": "aiortc inference server",
+            "hint": "add ?device_id=<id> query parameter to fetch metrics",
+        }
+    )
 
 
 async def health(request):


### PR DESCRIPTION
## Summary
- help users fetch metrics by hinting at device_id in root endpoint
- log same hint in legacy aiohttp server

## Testing
- `python -m py_compile server/app.py server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a61a1e45e0832c8be579e62a2c2dbb