### PR TITLE
Return latest per-frame metrics via root endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Then open **http://localhost:3000** on your laptop. A QR code appears — scan i
     ]
   }
   ```
+  The backend also persists these entries per device. The most recent entry
+  for a device can be fetched via HTTP:
+
+  ```bash
+  curl "http://localhost:8000/?device_id=<id>"
+  ```
+  which returns a JSON object in the same format as above.
 - **E2E latency per frame:** `overlay_display_ts - capture_ts`
 - **Server latency:** `inference_ts - recv_ts`
 - **Network latency:** `recv_ts - capture_ts`

--- a/server/app.py
+++ b/server/app.py
@@ -22,14 +22,26 @@ detector = Detector()
 
 @app.get("/")
 async def index(device_id: str | None = None):
-    """Return server status or metrics for a specific device."""
+    """Return server status or the latest metrics for a specific device.
+
+    When ``device_id`` is provided, this endpoint returns the most recent
+    per-frame metrics entry written for that device.  The metrics file is
+    appended to by the ``/offer`` handler and contains one JSON object per
+    line.  If no metrics are available yet for the device, an empty object is
+    returned.  When ``device_id`` is omitted, a simple status message is
+    returned instead.
+    """
+
     if device_id:
         path = f"{device_id}_metrics.json"
         if os.path.exists(path):
             with open(path, "r", encoding="utf-8") as f:
+                # load all lines and return the most recent entry
                 data = [json.loads(line) for line in f if line.strip()]
-            return {"device_id": device_id, "metrics": data}
-        return {"device_id": device_id, "metrics": []}
+            if data:
+                return data[-1]
+        return {}
+
     return {
         "message": "aiortc inference server",
         "hint": "add ?device_id=<id> query parameter to fetch metrics",


### PR DESCRIPTION
## Summary
- Return the most recent per-frame metrics for a device via `GET /?device_id=<id>` instead of a status wrapper
- Document how to fetch metrics directly from the backend

## Testing
- `python -m py_compile server/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a63244b71c832c8c233c4a49ffac1d