### PR TITLE
Expose device ID and allow fetching metrics by device

### DIFF
--- a/scripts/print_metrics.py
+++ b/scripts/print_metrics.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Fetch and print backend metrics for given device IDs.
+
+Usage:
+  python scripts/print_metrics.py DEVICE_ID [DEVICE_ID ...] [--url http://localhost:8000]
+"""
+
+import argparse
+import json
+from urllib.request import urlopen
+
+
+def fetch_metrics(device_id: str, base_url: str) -> dict:
+    """Fetch metrics for a device ID from the backend server."""
+    url = f"{base_url}/?device_id={device_id}"
+    with urlopen(url) as resp:
+        return json.load(resp)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Print backend metrics for specified device IDs"
+    )
+    parser.add_argument("device_ids", nargs="+", help="Device IDs to query")
+    parser.add_argument(
+        "--url",
+        default="http://localhost:8000",
+        help="Base URL of the backend server (default: http://localhost:8000)",
+    )
+    args = parser.parse_args()
+
+    for device_id in args.device_ids:
+        data = fetch_metrics(device_id, args.url)
+        metrics = data.get("metrics", [])
+        print(f"Metrics for {device_id}:")
+        print(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/web/src/components/StatsPanel.tsx
+++ b/web/src/components/StatsPanel.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { MetricSummary } from '../lib/metrics';
+import { deviceId } from '../lib/device';
 
 export default function StatsPanel({ metrics }: { metrics: MetricSummary }) {
   return (
     <div>
+      <div>Device: {deviceId}</div>
       <div>Samples: {metrics.count}</div>
       <div>P50: {metrics.p50.toFixed(1)} ms</div>
       <div>P95: {metrics.p95.toFixed(1)} ms</div>


### PR DESCRIPTION
## Summary
- show the current device ID in the stats panel
- add a helper script to fetch backend metrics for one or more device IDs

## Testing
- `python -m py_compile scripts/print_metrics.py`
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a714ed6c20832c8ea612de9ff676a7