### PR TITLE
feat: support https for mobile access

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ docker compose up --build
 ```
 This exposes the Vite app at http://localhost:3000 and the AIORTC backend at http://localhost:8000. For remote phone access over HTTPS, run a tunnel such as `ngrok http 3000` and use the forwarded URL.
 
+### Serving the web app over HTTPS
+
+Mobile browsers require a secure origin for `getUserMedia`. When accessing the app via a LAN IP (e.g. `http://10.0.0.5:3000`), the camera will be blocked on plain HTTP. The bundled web server can run over HTTPS by providing a certificate:
+
+```bash
+cd web
+SSL_KEY=path/to/key.pem SSL_CERT=path/to/cert.pem HTTPS=true npm run dev
+```
+
+Generate a self-signed cert for development with `openssl`:
+
+```bash
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout key.pem -out cert.pem
+```
+
+The QR code will automatically use `https://` for non-local hosts.
+
 ## One-command start
 ```bash
 git clone <this-repo>

--- a/web/server.js
+++ b/web/server.js
@@ -2,6 +2,8 @@ import express from 'express'
 import { WebSocketServer } from 'ws'
 import path from 'path'
 import http from 'http'
+import https from 'https'
+import fs from 'fs'
 import { fileURLToPath } from 'url'
 import getPort, { portNumbers } from 'get-port'
 import mime from 'mime'
@@ -123,8 +125,22 @@ app.post('/api/bench/push', (req, res) => {
 app.use(express.static(path.join(__dirname, 'dist')))
 app.use(express.static(path.join(__dirname, 'public')))
 
-// ----- SINGLE HTTP SERVER + WS on same port -----
-const httpServer = http.createServer(app)
+// ----- SINGLE HTTP/HTTPS SERVER + WS on same port -----
+// Allow serving over HTTPS when SSL cert/key are provided. Browsers block
+// camera/mic access on plain HTTP for non-localhost origins, so enabling HTTPS
+// lets phones join via IP without getUserMedia failures.
+let httpServer
+if (process.env.HTTPS === 'true') {
+  const keyPath = process.env.SSL_KEY || path.join(__dirname, 'cert', 'key.pem')
+  const certPath = process.env.SSL_CERT || path.join(__dirname, 'cert', 'cert.pem')
+  const options = {
+    key: fs.readFileSync(keyPath),
+    cert: fs.readFileSync(certPath),
+  }
+  httpServer = https.createServer(options, app)
+} else {
+  httpServer = http.createServer(app)
+}
 const wss = new WebSocketServer({ server: httpServer, path: '/signal' })
 
 let peers = []
@@ -141,7 +157,8 @@ const preferred = Number(process.env.PORT) || 3000
 const port = await getPort({ port: portNumbers(preferred, preferred + 100) })
 
 httpServer.listen(port, '0.0.0.0', () => {
-  console.log(`Web server listening on http://0.0.0.0:${port}`)
+  const proto = process.env.HTTPS === 'true' ? 'https' : 'http'
+  console.log(`Web server listening on ${proto}://0.0.0.0:${port}`)
 })
 
 // helpful debug

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,7 +14,12 @@ export default function App() {
   const [lowRes, setLowRes] = useState(true);
   const [detections, setDetections] = useState<Detection[]>([]);
   const [serverDown, setServerDown] = useState(false);
-  const [joinUrl, setJoinUrl] = useState(() => window.location.origin);
+  const [joinUrl, setJoinUrl] = useState(() => {
+    const loc = window.location
+    const isLocalHost = ['localhost', '127.0.0.1'].includes(loc.hostname)
+    const proto = !isLocalHost && loc.protocol === 'http:' ? 'https:' : loc.protocol
+    return `${proto}//${loc.host}`
+  });
   const metricsRef = useRef(new Metrics());
   const videoRef = useRef<HTMLVideoElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -223,7 +228,16 @@ export default function App() {
       .then(res => (res.ok ? res.text() : ''))
       .then(text => {
         const t = text.trim();
-        if (t) setJoinUrl(t);
+        if (t) {
+          try {
+            const u = new URL(t)
+            const isLocal = ['localhost', '127.0.0.1'].includes(u.hostname)
+            if (!isLocal && u.protocol === 'http:') u.protocol = 'https:'
+            setJoinUrl(u.toString())
+          } catch {
+            setJoinUrl(t)
+          }
+        }
       })
       .catch(() => {});
   }, []);


### PR DESCRIPTION
## Summary
- add optional HTTPS server to allow camera access from phones
- generate QR codes with https when not on localhost
- document self-signed certificate setup

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a7376bf93c832c96a5d6b25a564eb4