### PR TITLE
Handle getUserMedia in insecure contexts

### DIFF
--- a/web/public/join.html
+++ b/web/public/join.html
@@ -121,15 +121,36 @@
     
     joinBtn.addEventListener('click', async () => {
       try {
+        const mediaDevices = navigator.mediaDevices;
+        const getUserMedia = mediaDevices?.getUserMedia
+          || navigator.getUserMedia
+          || navigator.webkitGetUserMedia
+          || navigator.mozGetUserMedia;
+
+        if (!window.isSecureContext || !getUserMedia) {
+          throw new Error('getUserMedia requires HTTPS or localhost');
+        }
+
         // Request camera access
-        stream = await navigator.mediaDevices.getUserMedia({
-          video: {
-            width: { ideal: 320 },
-            height: { ideal: 256 },
-            frameRate: { ideal: 30 }
-          },
-          audio: false
-        });
+        stream = mediaDevices?.getUserMedia
+          ? await mediaDevices.getUserMedia({
+              video: {
+                width: { ideal: 320 },
+                height: { ideal: 256 },
+                frameRate: { ideal: 30 }
+              },
+              audio: false
+            })
+          : await new Promise((resolve, reject) =>
+              getUserMedia.call(navigator, {
+                video: {
+                  width: { ideal: 320 },
+                  height: { ideal: 256 },
+                  frameRate: { ideal: 30 }
+                },
+                audio: false
+              }, resolve, reject)
+            );
         
         // Show preview
         preview.srcObject = stream;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,16 +43,24 @@ export default function App() {
         },
         audio: false
       };
-      if (
-        !navigator.mediaDevices ||
-        !navigator.mediaDevices.getUserMedia
-      ) {
-        console.error('getUserMedia is not supported in this browser');
+      const mediaDevices = navigator.mediaDevices;
+      const getUserMedia = mediaDevices?.getUserMedia
+        || (navigator as any).getUserMedia
+        || (navigator as any).webkitGetUserMedia
+        || (navigator as any).mozGetUserMedia;
+
+      if (!window.isSecureContext || !getUserMedia) {
+        console.error('getUserMedia requires HTTPS or localhost');
         setServerDown(true);
         return;
       }
+
       try {
-        const stream = await navigator.mediaDevices.getUserMedia(constraints);
+        const stream = mediaDevices?.getUserMedia
+          ? await mediaDevices.getUserMedia(constraints)
+          : await new Promise<MediaStream>((resolve, reject) =>
+              getUserMedia.call(navigator, constraints, resolve, reject)
+            );
         if (streamRef.current) {
           streamRef.current.getTracks().forEach(t => t.stop());
         }


### PR DESCRIPTION
## Summary
- Add cross-browser `getUserMedia` fallback and secure-context check in main app
- Safeguard join page with same fallback to handle HTTP vs HTTPS issues

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a742def728832ca4c2873314984c72