### PR TITLE
feat(web): allow overriding server url

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -24,7 +24,10 @@ app.use((req, res, next) => {
 // expose MODE to browser
 app.get('/env.js', (req, res) => {
   const mode = process.env.MODE || 'wasm'
-  res.type('application/javascript').send(`window.MODE="${mode}";`)
+  const serverUrl = process.env.SERVER_URL || ''
+  const lines = [`window.MODE="${mode}";`]
+  if (serverUrl) lines.push(`window.SERVER_URL="${serverUrl}";`)
+  res.type('application/javascript').send(lines.join('\n'))
 })
 
 // Simple metrics aggregator keyed by device ID

--- a/web/src/lib/webrtc.ts
+++ b/web/src/lib/webrtc.ts
@@ -10,8 +10,11 @@ export interface DetectionMessage {
 
 // Base URL for the inference server. Using the same value everywhere ensures
 // that the frontend consistently talks to the correct backend port regardless
-// of the current origin (e.g. dev server on 3000).
-export const SERVER_URL = `${window.location.protocol}//${window.location.hostname}:8000`;
+// of the current origin (e.g. dev server on 3000). Allow overriding via
+// window.SERVER_URL so deployments can specify a custom endpoint or protocol.
+export const SERVER_URL =
+  (window as any).SERVER_URL ||
+  `${window.location.protocol}//${window.location.hostname}:8000`;
 
 export async function initWebRTC(
   stream: MediaStream,


### PR DESCRIPTION
## Summary
- allow the backend URL to be overridden via `SERVER_URL` env variable
- update WebRTC client to read `window.SERVER_URL`

## Testing
- `npm --prefix web run build`
- `cd server && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a743f5fb44832c80e72bd5aa1089e0