### PR TITLE
Record default server and network latencies

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -134,16 +134,19 @@ export default function App() {
         if (vid && vid.readyState >= 2) {
           const bitmap = await captureFrame();
           if (bitmap) {
-            infer(bitmap).then(output => {
-              if (output) {
-                const { capture_ts, inference_ts, detections } = output;
-                setDetections(detections);
-                metricsRef.current.record(capture_ts, inference_ts);
-                frameCountRef.current++;
-              }
-            }).catch(err => {
-              console.error(err);
-            });
+            infer(bitmap)
+              .then(output => {
+                if (output) {
+                  const { capture_ts, detections } = output;
+                  const inference_ts = performance.now();
+                  setDetections(detections);
+                  metricsRef.current.record(capture_ts, inference_ts);
+                  frameCountRef.current++;
+                }
+              })
+              .catch(err => {
+                console.error(err);
+              });
           }
         }
       }

--- a/web/src/lib/metrics.ts
+++ b/web/src/lib/metrics.ts
@@ -13,9 +13,11 @@ export class Metrics {
 
   record(sent: number, received: number, extra?: { server?: number; network?: number }) {
     const latency = received - sent;
+    const srv = extra?.server ?? latency;
+    const net = extra?.network ?? 0;
     this.e2e.push(latency);
-    if (typeof extra?.server === 'number') this.server.push(extra.server);
-    if (typeof extra?.network === 'number') this.network.push(extra.network);
+    this.server.push(srv);
+    this.network.push(net);
     // Best-effort push to backend bench aggregator. Ignore failures so normal
     // operation is unaffected if the endpoint is missing (e.g. outside bench
     // runs). Only attempt this when building for production to avoid noisy
@@ -24,9 +26,9 @@ export class Metrics {
       const payload: Record<string, number | string> = {
         device_id: deviceId,
         e2e: latency,
+        server_latency_ms: srv,
+        network_latency_ms: net,
       };
-      if (typeof extra?.server === 'number') payload.server_latency_ms = extra.server;
-      if (typeof extra?.network === 'number') payload.network_latency_ms = extra.network;
       void fetch('/api/bench/push', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Record server latency and network latency for every sample, defaulting to end-to-end latency and zero
- Use main-thread timestamps for inference completion to avoid negative latencies

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7477a356c832caa36dc41659f8ed4