### PR TITLE
Expose server and network latency summaries

### DIFF
--- a/web/src/components/StatsPanel.tsx
+++ b/web/src/components/StatsPanel.tsx
@@ -1,14 +1,23 @@
 import React from 'react';
-import { MetricSummary } from '../lib/metrics';
+import { MetricSummary, LatencySummary } from '../lib/metrics';
 import { deviceId } from '../lib/device';
 
-export default function StatsPanel({ metrics }: { metrics: MetricSummary }) {
+export default function StatsPanel({ metrics }: { metrics: LatencySummary }) {
+  const render = (label: string, m: MetricSummary) => (
+    <div>
+      <div><strong>{label}</strong></div>
+      <div>Samples: {m.count}</div>
+      <div>P50: {m.p50.toFixed(1)} ms</div>
+      <div>P95: {m.p95.toFixed(1)} ms</div>
+    </div>
+  );
+
   return (
     <div>
       <div>Device: {deviceId}</div>
-      <div>Samples: {metrics.count}</div>
-      <div>P50: {metrics.p50.toFixed(1)} ms</div>
-      <div>P95: {metrics.p95.toFixed(1)} ms</div>
+      {render('End-to-end', metrics.e2e)}
+      {render('Server', metrics.server)}
+      {render('Network', metrics.network)}
     </div>
   );
 }

--- a/web/src/lib/metrics.ts
+++ b/web/src/lib/metrics.ts
@@ -6,6 +6,19 @@ export interface MetricSummary {
   p95: number;
 }
 
+export interface LatencySummary {
+  e2e: MetricSummary;
+  server: MetricSummary;
+  network: MetricSummary;
+}
+
+const summarize = (arr: number[]): MetricSummary => {
+  const s = [...arr].sort((a, b) => a - b);
+  const q = (p: number) =>
+    s.length ? s[Math.min(s.length - 1, Math.floor(p * (s.length - 1)))] : 0;
+  return { count: s.length, p50: q(0.5), p95: q(0.95) };
+};
+
 export class Metrics {
   private e2e: number[] = [];
   private server: number[] = [];
@@ -39,24 +52,15 @@ export class Metrics {
     }
   }
 
-  summary(): MetricSummary {
-    const arr = [...this.e2e].sort((a, b) => a - b);
-    const q = (p: number) =>
-      arr.length ? arr[Math.min(arr.length - 1, Math.floor(p * (arr.length - 1)))] : 0;
+  summary(): LatencySummary {
     return {
-      count: arr.length,
-      p50: q(0.5),
-      p95: q(0.95)
+      e2e: summarize(this.e2e),
+      server: summarize(this.server),
+      network: summarize(this.network),
     };
   }
 
   toJSON() {
-    const summarize = (arr: number[]): MetricSummary => {
-      const s = [...arr].sort((a, b) => a - b);
-      const q = (p: number) =>
-        s.length ? s[Math.min(s.length - 1, Math.floor(p * (s.length - 1)))] : 0;
-      return { count: s.length, p50: q(0.5), p95: q(0.95) };
-    };
     return {
       e2e_latency_ms: summarize(this.e2e),
       server_latency_ms: summarize(this.server),


### PR DESCRIPTION
## Summary
- add aggregated latency summaries for end-to-end, server, and network metrics
- display separate latency statistics in the stats panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7497460f8832cbbd8596ce010aa93