### PR TITLE
Include device ID in backend detection messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Then open **http://localhost:3000** on your laptop. A QR code appears — scan i
 - **Per-frame JSON (server → client)** over WS in server mode:
   ```json
   {
+    "device_id": "browser_id",
     "frame_id": "string_or_int",
     "capture_ts": 1690000000000,
     "recv_ts": 1690000000100,

--- a/server/app.py
+++ b/server/app.py
@@ -88,11 +88,12 @@ async def index(device_id: str | None = None):
         }]
     
     return {
+        "device_id": "sample_device",
         "frame_id": current_time,
         "capture_ts": current_time - 120,
         "recv_ts": recv_ts,
         "inference_ts": inference_ts,
-        "detections": detections
+        "detections": detections,
     }
 
 
@@ -150,6 +151,7 @@ async def offer(request: Request, device_id: str = Query(...)):
                 ]
                 inference_ts = int(time.time() * 1000)
                 message = {
+                    "device_id": device_id,
                     "frame_id": frame_id,
                     "capture_ts": capture_ts,
                     "recv_ts": recv_ts,

--- a/server/main.py
+++ b/server/main.py
@@ -26,6 +26,7 @@ async def index(request):
     # Return a sample detection response format instead of the hint message
     return web.json_response(
         {
+            "device_id": "sample_device",
             "frame_id": "sample",
             "capture_ts": int(time.time() * 1000),
             "recv_ts": int(time.time() * 1000),
@@ -92,14 +93,13 @@ async def offer(request):
                 detections = tracker.update(detections)
                 inference_ts = int(time.time() * 1000)
                 message = {
+                    "device_id": device_id or "unknown",
                     "frame_id": frame_id,
                     "capture_ts": capture_ts,
                     "recv_ts": recv_ts,
                     "inference_ts": inference_ts,
                     "detections": detections,
                 }
-                # Print device ID followed by the detection message
-                print(device_id or "unknown")
                 print(json.dumps(message))
                 if metrics_file:
                     metrics_file.write(json.dumps(message) + "\n")


### PR DESCRIPTION
## Summary
- Include `device_id` in sample detection response and per-frame messages in the aiohttp server.
- Attach `device_id` to detection messages in the FastAPI backend as well.
- Document device ID field in README.

## Testing
- `python -m py_compile server/main.py server/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac8c336bc4832cacd841ea5bba02be