### PR TITLE
Default to known device ID in server index

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -26,10 +26,16 @@ async def index(device_id: str | None = None):
     """Return sample detection or stored metrics for a device.
 
     If metrics have been recorded for the requested ``device_id`` they are
-    returned. Otherwise a sample detection payload is generated with the
-    provided ``device_id`` (falling back to ``"sample_device"`` when not
-    specified).
+    returned. When no ``device_id`` is provided the first known device (if
+    any) is used. Otherwise a sample detection payload is generated with the
+    provided ``device_id`` (falling back to ``"sample_device"`` when none is
+    available).
     """
+    if not device_id and device_metrics:
+        # Default to the first device that has reported metrics so the client
+        # doesn't have to explicitly provide its identifier.
+        device_id = next(iter(device_metrics))
+
     if device_id and device_id in device_metrics:
         return {"device_id": device_id, "metrics": device_metrics.get(device_id, [])}
     

--- a/server/main.py
+++ b/server/main.py
@@ -15,6 +15,15 @@ detector = Detector()
 async def index(request):
     """Return server status or metrics for a specific device."""
     device_id = request.query.get("device_id")
+
+    if not device_id:
+        # Try to infer a device ID from existing metric files if one wasn't
+        # explicitly requested.
+        for fname in os.listdir("."):
+            if fname.endswith("_metrics.json"):
+                device_id = fname.removesuffix("_metrics.json")
+                break
+
     if device_id:
         path = f"{device_id}_metrics.json"
         if os.path.exists(path):
@@ -22,11 +31,11 @@ async def index(request):
                 data = [json.loads(line) for line in f if line.strip()]
             return web.json_response({"device_id": device_id, "metrics": data})
         return web.json_response({"device_id": device_id, "metrics": []})
-    
-    # Return a sample detection response format instead of the hint message
+
+    # Return a sample detection response format when no metrics are available
     return web.json_response(
         {
-            "device_id": "sample_device",
+            "device_id": device_id or "sample_device",
             "frame_id": "sample",
             "capture_ts": int(time.time() * 1000),
             "recv_ts": int(time.time() * 1000),


### PR DESCRIPTION
## Summary
- Use first recorded device ID for index endpoint when no device_id is provided so sample detections mirror frontend device names.
- Apply the same fallback logic to the legacy aiohttp server.

## Testing
- `python -m py_compile server/app.py server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac9c50f1a4832cabd0aff530a8e54f